### PR TITLE
Amano/label

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -18,6 +18,8 @@ class Issue < ApplicationRecord
   belongs_to :assignee, class_name: "User", foreign_key: :assignee_id, optional: true
 
   has_many :comments, -> { order(created_at: :asc) }, class_name: 'Comment'
+  has_many :labelings, class_name: "Labeling", foreign_key: :issue_id, dependent: :destroy
+  has_many :labels, through: :labelings, source: :label
 
   enum status: { close: 0, open: 1 }
 

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -15,6 +15,9 @@ class Label < ApplicationRecord
 
   validate :color_code_check
 
+  has_many :labelings, class_name: "Labeling", foreign_key: :label_id, dependent: :destroy
+  has_many :issues, through: :labelings, source: :label
+
   private
   def color_code_check
     errors.add(:base, "Invalid Color") unless hexadecimal_color_code?(color_code)

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -16,7 +16,7 @@ class Label < ApplicationRecord
   validate :color_code_check
 
   has_many :labelings, class_name: "Labeling", foreign_key: :label_id, dependent: :destroy
-  has_many :issues, through: :labelings, source: :label
+  has_many :issues, through: :labelings, source: :issue
 
   private
   def color_code_check

--- a/app/models/labeling.rb
+++ b/app/models/labeling.rb
@@ -1,0 +1,4 @@
+class Labeling < ApplicationRecord
+  belongs_to :label_id
+  belongs_to :issue_id
+end

--- a/app/models/labeling.rb
+++ b/app/models/labeling.rb
@@ -1,4 +1,4 @@
 class Labeling < ApplicationRecord
-  belongs_to :label_id
-  belongs_to :issue_id
+  belongs_to :label
+  belongs_to :issue
 end

--- a/db/migrate/20160609015215_create_labelings.rb
+++ b/db/migrate/20160609015215_create_labelings.rb
@@ -1,0 +1,10 @@
+class CreateLabelings < ActiveRecord::Migration[5.0]
+  def change
+    create_table :labelings do |t|
+      t.references :label_id, foreign_key: true
+      t.references :issue_id, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160609015215_create_labelings.rb
+++ b/db/migrate/20160609015215_create_labelings.rb
@@ -1,8 +1,8 @@
 class CreateLabelings < ActiveRecord::Migration[5.0]
   def change
     create_table :labelings do |t|
-      t.references :label_id, foreign_key: true
-      t.references :issue_id, foreign_key: true
+      t.references :label, foreign_key: true
+      t.references :issue, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160609011427) do
+ActiveRecord::Schema.define(version: 20160609015215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,15 @@ ActiveRecord::Schema.define(version: 20160609011427) do
     t.integer  "assignee_id"
   end
 
+  create_table "labelings", force: :cascade do |t|
+    t.integer  "label_id"
+    t.integer  "issue_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["issue_id"], name: "index_labelings_on_issue_id", using: :btree
+    t.index ["label_id"], name: "index_labelings_on_label_id", using: :btree
+  end
+
   create_table "labels", force: :cascade do |t|
     t.string   "name"
     t.string   "color_code"
@@ -48,4 +57,6 @@ ActiveRecord::Schema.define(version: 20160609011427) do
   end
 
   add_foreign_key "comments", "issues"
+  add_foreign_key "labelings", "issues"
+  add_foreign_key "labelings", "labels"
 end

--- a/test/fixtures/labelings.yml
+++ b/test/fixtures/labelings.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  label_id: one
+  issue_id: one
+
+two:
+  label_id: two
+  issue_id: two

--- a/test/models/labeling_test.rb
+++ b/test/models/labeling_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LabelingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Issueにラベルをつけれるようにしたい #10
- Issue - Labelの中間テーブルを作る
- IssueControllerのcreate, updateで`label_ids`を受けてデータが作られるようにしたい

``` bash
[30] pry(main)> i = Issue.last
  Issue Load (0.7ms)  SELECT  "issues".* FROM "issues" ORDER BY "issues"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> #<Issue:0x007fe09cb535e0
 id: 12,
 title: "hoege",
 status: "open",
 created_at: Thu, 09 Jun 2016 10:37:07 JST +09:00,
 updated_at: Thu, 09 Jun 2016 10:37:49 JST +09:00,
 content: "uga",
 assignee_id: nil>
[32] pry(main)> i.labels.map(&:id)
=> [3, 4]
[33] pry(main)> i.label_ids = [1,2]
  Label Load (0.8ms)  SELECT "labels".* FROM "labels" WHERE "labels"."id" IN (1, 2)
   (0.1ms)  BEGIN
  SQL (0.3ms)  DELETE FROM "labelings" WHERE "labelings"."issue_id" = $1 AND "labelings"."label_id" IN (3, 4)  [["issue_id", 12]]
  Issue Load (0.4ms)  SELECT  "issues".* FROM "issues" WHERE "issues"."id" = $1 LIMIT $2  [["id", 12], ["LIMIT", 1]]
  SQL (0.5ms)  INSERT INTO "labelings" ("label_id", "issue_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"  [["label_id", 1], ["issue_id", 12], ["created_at", 2016-06-09 02:04:09 UTC], ["updated_at", 2016-06-09 02:04:09 UTC]]
  Issue Load (0.3ms)  SELECT  "issues".* FROM "issues" WHERE "issues"."id" = $1 LIMIT $2  [["id", 12], ["LIMIT", 1]]
  SQL (0.5ms)  INSERT INTO "labelings" ("label_id", "issue_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"  [["label_id", 2], ["issue_id", 12], ["created_at", 2016-06-09 02:04:09 UTC], ["updated_at", 2016-06-09 02:04:09 UTC]]
   (2.2ms)  COMMIT
=> [1, 2]
[34] pry(main)> i.labels.reload.map(&:id)
  Label Load (0.8ms)  SELECT "labels".* FROM "labels" INNER JOIN "labelings" ON "labels"."id" = "labelings"."label_id" WHERE "labelings"."issue_id" = $1  [["issue_id", 12]]
=> [1, 2]
```
